### PR TITLE
Added a new cli option, --delay-range. The in-stock check will use a …

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -83,6 +83,12 @@ def main():
     "--delay", type=float, default=3.0, help="Time to wait between checks for item[s]"
 )
 @click.option(
+    "--delay-range",
+    type=(float, float),
+    default=(None, None),   # will use `delay` unless delay-range is specified
+    help="Time to wait between checks for item[s]. Random value between specified range. eg. for `--delay-range 3.5 4.2` the delay would be between 3.5 and 4.2 seconds."
+)
+@click.option(
     "--checkshipping",
     is_flag=True,
     help="Factor shipping costs into reserve price and look for items with a shipping price",
@@ -115,6 +121,7 @@ def amazon(
     headless,
     test,
     delay,
+    delay_range,
     checkshipping,
     detailed,
     used,
@@ -128,6 +135,9 @@ def amazon(
     else:
         selenium_utils.yes_amazon_image()
 
+    if delay_range == (None, None):
+        delay_range = (delay, delay)
+
     amzn_obj = Amazon(
         headless=headless,
         notification_handler=notification_handler,
@@ -139,7 +149,7 @@ def amazon(
         no_screenshots=no_screenshots,
         disable_presence=disable_presence,
     )
-    amzn_obj.run(delay=delay, test=test)
+    amzn_obj.run(delay_range, test=test)
 
 
 @click.command()

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -264,7 +264,7 @@ class Amazon:
             "password": password,
         }
 
-    def run(self, delay=3, test=False):
+    def run(self, delay_range=(3.0, 3.0), test=False):
         log.info("Waiting for home page.")
         while True:
             try:
@@ -290,7 +290,7 @@ class Amazon:
         log.info("Checking stock for items.")
 
         while keep_going:
-            asin = self.run_asins(delay)
+            asin = self.run_asins(delay_range)
             # found something in stock and under reserve
             # initialize loop limiter variables
             self.try_to_checkout = True
@@ -386,9 +386,15 @@ class Amazon:
         log.info(f"Logged in as {self.username}")
 
     @debug
-    def run_asins(self, delay):
+    def run_asins(self, delay_range):
         found_asin = False
         while not found_asin:
+            if delay_range[0] != delay_range[1]:
+                delay = random.uniform(delay_range[0], delay_range[1])
+                log.debug(f"New between {delay_range[0]} and {delay_range[1]} is {delay}")
+            else:
+                delay = delay_range[0]
+
             for i in range(len(self.asin_list)):
                 for asin in self.asin_list[i]:
                     if self.check_stock(asin, self.reserve_min[i], self.reserve_max[i]):


### PR DESCRIPTION
…random delay within the specified range.

The default value for this is (None, None) because I needed a way to check for the existence of, and utilize, the main `delay` option.
Unless we specify a default, the click library complains. Might be a bug in click.