### PR TITLE
Add encryption pass CLI arg

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -140,7 +140,7 @@ def amazon(
     disable_presence,
     disable_sound,
     slow_mode,
-    encryption_pass,
+    p,
 ):
     if no_image:
         selenium_utils.no_amazon_image()
@@ -161,7 +161,7 @@ def amazon(
         no_screenshots=no_screenshots,
         disable_presence=disable_presence,
         slow_mode=slow_mode,
-        encryption_pass=encryption_pass,
+        encryption_pass=p,
     )
     amzn_obj.run(delay=delay, test=test)
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -121,7 +121,7 @@ def main():
     help="Uses normal page load strategy for selenium. Default is none",
 )
 @click.option(
-    "--encryption-pass",
+    "--p",
     type=str,
     default=None,
     help="Pass in encryption file password as argument",

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -120,6 +120,12 @@ def main():
     default=False,
     help="Uses normal page load strategy for selenium. Default is none",
 )
+@click.option(
+    "--encryption-pass",
+    type=str,
+    default=None,
+    help="Pass in encryption file password as argument",
+)
 @notify_on_crash
 def amazon(
     no_image,
@@ -134,6 +140,7 @@ def amazon(
     disable_presence,
     disable_sound,
     slow_mode,
+    encryption_pass,
 ):
     if no_image:
         selenium_utils.no_amazon_image()
@@ -154,6 +161,7 @@ def amazon(
         no_screenshots=no_screenshots,
         disable_presence=disable_presence,
         slow_mode=slow_mode,
+        encryption_pass=encryption_pass,
     )
     amzn_obj.run(delay=delay, test=test)
 

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -188,6 +188,7 @@ class Amazon:
         no_screenshots=False,
         disable_presence=False,
         slow_mode=False,
+        encryption_pass=None,
     ):
         self.notification_handler = notification_handler
         self.asin_list = []
@@ -224,7 +225,7 @@ class Amazon:
                 raise
 
         if os.path.exists(CREDENTIAL_FILE):
-            credential = load_encrypted_config(CREDENTIAL_FILE)
+            credential = load_encrypted_config(CREDENTIAL_FILE, encryption_pass)
             self.username = credential["username"]
             self.password = credential["password"]
         else:

--- a/utils/encryption.py
+++ b/utils/encryption.py
@@ -61,7 +61,7 @@ def create_encrypted_config(data, file_path):
         exit(0)
 
 
-def load_encrypted_config(config_path):
+def load_encrypted_config(config_path, encrypted_pass=None):
     """Decrypts a previously encrypted credential file and returns the contents back
     to the calling thread."""
     log.info("Reading credentials from: " + config_path)
@@ -69,7 +69,12 @@ def load_encrypted_config(config_path):
         data = json_file.read()
     try:
         if "nonce" in data:
-            password = stdiomask.getpass(prompt="Credential file password: ", mask="*")
+            if encrypted_pass is None:
+                password = stdiomask.getpass(
+                    prompt="Credential file password: ", mask="*"
+                )
+            else:
+                password = encrypted_pass
             decrypted = decrypt(data, password)
             return json.loads(decrypted)
         else:


### PR DESCRIPTION
Adds command line argument --encryption-pass for people that may want to not have to do the login manually. Useful for people who may want to schedule jobs using the script and not having to enter the password through a stdin pipe.

Usage:

`python app.py amazon --encryption-pass <password>`