### PR TITLE
amazon.py - make path_to_prefs platform agnostic

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -1110,9 +1110,11 @@ class Amazon:
             self.setup_driver = False
 
         # Delete crashed, so restore pop-up doesn't happen
-        path_to_prefs = (
-            os.path.dirname(os.path.abspath("__file__"))
-            + "\\.profile-amz\\Default\\Preferences"
+        path_to_prefs = os.path.join(
+            os.path.dirname(os.path.abspath("__file__")),
+            ".profile-amz",
+            "Default",
+            "Preferences",
         )
         with fileinput.FileInput(path_to_prefs, inplace=True) as file:
             for line in file:


### PR DESCRIPTION
fixed path_to_prefs to be platform agnostic

Co-Authored-By: dannotdaniel <27717952+dannotdaniel@users.noreply.github.com>