### PR TITLE
Hotfix 0.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Read through this document and the cheat sheet linked in the next sections. See 
 ## Installation
 
 Easy_XII has created a great cheat sheet for getting started, [please follow this guide](https://docs.google.com/document/d/1grN282tPodM9N57bPq4bbNyKZC01t_4A-sLpzzu_7lM/).
+**Note:** that we do not control the contents of this document, so use some common sense when configuring the bot. Do not ask us
+why the bot does not purchase an $8.49 item when the minimum purchase price is set to $10 in the configuration file that YOU are supposed to update  
 
 This project uses [Pipenv](https://pypi.org/project/pipenv/) to manage dependencies. Hop in my [Discord](https://discord.gg/qDY2QBtAW6) if you have ideas, need help or just want to tell us about how you got your new toys. 
 
@@ -30,6 +32,8 @@ pip install pipenv
 pipenv shell 
 pipenv install
 ```
+
+NOTE: YOU SHOULD RUN `pipenv shell` and `pipenv install` ANY TIME YOU UPDATE, IN CASE THE DEPENDENCIES HAVE CHANGED!
 
 Run it
 ```
@@ -57,7 +61,9 @@ Best Buy has been deprecated, see details below.
 ### Amazon 
 The following flags are specific to the Amazon scripts.  They the `[OPTIONS]` to be passed on the command-line to control
 the behavior of Amazon scanning and purchasing.  These can be added at the command line or added to a batch file/shell
- script (see `_Amazon.bat` in the root folder of the project).
+ script (see `_Amazon.bat` in the root folder of the project). **NOTE:** `--test` flag has been added to `_Amazon.bat` file by
+default. This should be deleted after you've verified that the bot works correctly for you. If you don't want your `_Amazon.bat`
+to be deleted when you update, you should rename it to something else.
 
 **Amazon flags**
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 We built this in response to the severe tech scalping situation that's happening right now. Almost every tech product that's coming
 out right now is being instantly brought out by scalping groups and then resold at at insane prices. $699 GPUs are being listed
-for $1700 on eBay, and these scalpers are buying 40 carts while normal consumers can't get a single one. Preorders for the PS5 are
+for $1700 on eBay, and these scalpers are buying 40 cards while normal consumers can't get a single one. Preorders for the PS5 are
 being resold for nearly $1000. Our take on this is that if we release a bot that anyone can use, for free, then the number of items 
 that scalpers can buy goes down and normal consumers can buy items for MSRP. 
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Options:
                       none
 
   --p TEXT            Pass in encryption file password as argument
+  --log-stock-check   Will log each stock check to terminal and log file
+  --shipping-bypass   Bot will attempt to click "Ship to this Address" button,
+                      if it pops up during checkout. 
+                      USE THIS OPTION AT YOUR OWN RISK!!!
+                      NOTE: There is no functionality to choose payment
+                      option, so bot may still fail during checkout
+                      
   --help              Show this message and exit.
 ```
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -126,6 +126,18 @@ def main():
     default=None,
     help="Pass in encryption file password as argument",
 )
+@click.option(
+    "--log-stock-check",
+    is_flag=True,
+    default=False,
+    help="writes stock check information to terminal and log",
+)
+@click.option(
+    "--shipping-bypass",
+    is_flag=True,
+    default=False,
+    help="Will attempt to click ship to address button. USE AT YOUR OWN RISK!",
+)
 @notify_on_crash
 def amazon(
     no_image,
@@ -141,6 +153,8 @@ def amazon(
     disable_sound,
     slow_mode,
     p,
+    log_stock_check,
+    shipping_bypass,
 ):
 
     notification_handler.sound_enabled = not disable_sound
@@ -159,6 +173,8 @@ def amazon(
         slow_mode=slow_mode,
         encryption_pass=p,
         no_image=no_image,
+        log_stock_check=log_stock_check,
+        shipping_bypass=shipping_bypass,
     )
     try:
         amzn_obj.run(delay=delay, test=test)

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -2,7 +2,16 @@ from datetime import datetime
 from functools import wraps
 from signal import signal, SIGINT
 
-import click
+try:
+    import click
+except ModuleNotFoundError:
+    print(
+        "You should try running pipenv shell and pipenv install per the install instructions"
+    )
+    print("Or you should only use Python 3.8.X per the instructions.")
+    print("If you are attempting to run multiple bots, this is not supported.")
+    print("You are on your own to figure this out.")
+    exit(0)
 import time
 
 from notifications.notifications import NotificationHandler, TIME_FORMAT

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -144,8 +144,16 @@ OUT_OF_STOCK = ["Out of Stock - AmazonSmile Checkout"]
 NO_SELLERS = [
     "Currently, there are no sellers that can deliver this item to your location.",
     "There are currently no listings for this search. Try a different refinement.",
-    "There are currently no listings for this search. Try a different refinement.",
     "There are currently no listings for this product in . Try changing the condition type.",
+    "Actualmente, no hay listas para este producto en . Intenta cambiar el tipo de condición.",
+    "Derzeit gibt es keine Verkäufer, die diesen Artikel an Ihren Standort liefern können.",
+    "Actualmente, no hay vendedores que puedan entregar este producto en tu ubicación.",
+    "Il n’y a actuellement aucun vendeur en mesure de livrer ce produit sur votre zone géographique.",
+    "Il n'y a actuellement pas de produits répondant à ces critères. Essayez de changer les filtres.",
+    "No existen listados para esta búsqueda. Probar con otro filtro.",
+    "In gibt es derzeit keine Listungen für dieses Produkt. Versuchen Sie, den Zustandstyp zu ändern.",
+    "Al momento, non ci sono seller in grado di spedire questo articolo alla tua sede.",
+    "Al momento non ci sono offerte per questo prodotto in . Prova a modificare il tipo di condizione.",
 ]
 
 # OFFER_PAGE_TITLES = ["Amazon.com: Buying Choices:"]

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -14,7 +14,7 @@ from chromedriver_py import binary_path  # this will get you the path variable
 from furl import furl
 from price_parser import parse_price
 from selenium import webdriver
-from selenium.common import exceptions
+from selenium.common import exceptions as sel_exceptions
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -202,6 +202,8 @@ class Amazon:
         slow_mode=False,
         encryption_pass=None,
         no_image=False,
+        log_stock_check=False,
+        shipping_bypass=False,
     ):
         self.notification_handler = notification_handler
         self.asin_list = []
@@ -223,6 +225,8 @@ class Amazon:
         self.setup_driver = True
         self.headless = headless
         self.no_image = no_image
+        self.log_stock_check = log_stock_check
+        self.shipping_bypass = shipping_bypass
 
         presence.enabled = not disable_presence
         presence.start_presence()
@@ -301,9 +305,8 @@ class Amazon:
         while True:
             try:
                 self.get_page(url=AMAZON_URLS["BASE_URL"])
-                # self.driver.get(AMAZON_URLS["BASE_URL"])
                 break
-            except Exception:
+            except sel_exceptions:
                 log.error(
                     "Couldn't talk to "
                     + AMAZON_URLS["BASE_URL"]
@@ -311,6 +314,13 @@ class Amazon:
                 )
                 time.sleep(3)
                 pass
+        cart_quantity = self.get_cart_count()
+        if cart_quantity > 0:
+            log.warning(f"Found {cart_quantity} item(s) in your cart.")
+            log.info("Delete all item(s) in cart before starting bot.")
+            log.info("Exiting now...")
+            time.sleep(5)
+            return
         self.handle_startup()
         if not self.is_logged_in():
             self.login()
@@ -318,6 +328,12 @@ class Amazon:
         self.send_notification(
             "Bot Logged in and Starting up", "Start-Up", self.take_screenshots
         )
+        if self.get_cart_count() > 0:
+            log.warning(f"Found {cart_quantity} item(s) in your cart.")
+            log.info("Delete all item(s) in cart before starting bot.")
+            log.info("Exiting now...")
+            time.sleep(5)
+            return
 
         keep_going = True
 
@@ -336,7 +352,7 @@ class Amazon:
                 try:
                     self.navigate_pages(test)
                 # if for some reason page transitions in the middle of checking elements, don't break the program
-                except exceptions.StaleElementReferenceException:
+                except sel_exceptions.StaleElementReferenceException:
                     pass
                 # if successful after running navigate pages, remove the asin_list from the list
                 if (
@@ -390,7 +406,7 @@ class Amazon:
 
             try:
                 self.driver.find_element_by_xpath(xpath).click()
-            except exceptions.NoSuchElementException:
+            except sel_exceptions.NoSuchElementException:
                 log.error("Log in button does not exist")
             log.info("Wait for Sign In page")
             time.sleep(self.page_wait_delay())
@@ -400,7 +416,7 @@ class Amazon:
         try:
             text = self.driver.find_element_by_id("nav-link-accountList").text
             return not any(sign_in in text for sign_in in SIGN_IN_TEXT)
-        except exceptions.NoSuchElementException:
+        except sel_exceptions.NoSuchElementException:
             return False
 
     @debug
@@ -413,13 +429,13 @@ class Amazon:
             try:
                 email_field = self.driver.find_element_by_xpath('//*[@id="ap_email"]')
                 break
-            except exceptions.NoSuchElementException:
+            except sel_exceptions.NoSuchElementException:
                 try:
                     password_field = self.driver.find_element_by_xpath(
                         '//*[@id="ap_password"]'
                     )
                     break
-                except exceptions.NoSuchElementException:
+                except sel_exceptions.NoSuchElementException:
                     pass
             if time.time() > timeout:
                 break
@@ -427,7 +443,7 @@ class Amazon:
         if email_field:
             try:
                 email_field.send_keys(self.username + Keys.RETURN)
-            except exceptions.ElementNotInteractableException:
+            except sel_exceptions.ElementNotInteractableException:
                 log.info("Email not needed.")
         else:
             log.info("Email not needed.")
@@ -442,7 +458,7 @@ class Amazon:
         log.info("Remember me checkbox")
         try:
             self.driver.find_element_by_xpath('//*[@name="rememberMe"]').click()
-        except exceptions.NoSuchElementException:
+        except sel_exceptions.NoSuchElementException:
             log.error("Remember me checkbox did not exist")
 
         log.info("Password")
@@ -455,7 +471,7 @@ class Amazon:
                     '//*[@id="ap_password"]'
                 )
                 break
-            except exceptions.NoSuchElementException:
+            except sel_exceptions.NoSuchElementException:
                 pass
             if time.time() > timeout:
                 break
@@ -468,7 +484,7 @@ class Amazon:
                 captcha_entry = self.driver.find_element_by_xpath(
                     '//*[@id="auth-captcha-guess"]'
                 )
-            except exceptions.NoSuchElementException:
+            except sel_exceptions.NoSuchElementException:
                 password_field.send_keys(Keys.RETURN)
                 self.wait_for_page_change(current_page)
         else:
@@ -511,6 +527,8 @@ class Amazon:
             for i in range(len(self.asin_list)):
                 for asin in self.asin_list[i]:
                     # start_time = time.time()
+                    if self.log_stock_check:
+                        log.info(f"Checking ASIN: {asin}.")
                     if self.check_stock(asin, self.reserve_min[i], self.reserve_max[i]):
                         return asin
                     # log.info(f"check time took {time.time()-start_time} seconds")
@@ -592,7 +610,7 @@ class Amazon:
                 test = self.driver.find_element_by_xpath(
                     '//*[@id="olpOfferList"]/div/p'
                 )
-            except exceptions.NoSuchElementException:
+            except sel_exceptions.NoSuchElementException:
                 pass
 
             if test and (test.text in NO_SELLERS):
@@ -711,6 +729,21 @@ class Amazon:
         # time.sleep(self.page_wait_delay())
 
         title = self.driver.title
+        # see if this resolves blank page title issue?
+        if title == "":
+            timeout_seconds = DEFAULT_MAX_TIMEOUT
+            log.debug(
+                f"Title was blank, checking to find a real title for {timeout_seconds} seconds"
+            )
+            timeout = self.get_timeout(timeout=timeout_seconds)
+            while True:
+                if self.driver.title != "":
+                    title = self.driver.title
+                    log.debug(f"found a real title: {title}.")
+                    break
+                if time.time() > timeout:
+                    log.debug("Time out reached, page title was still blank.")
+                    break
         if title in SIGN_IN_TITLES:
             self.login()
         elif title in CAPTCHA_PAGE_TITLES:
@@ -733,25 +766,136 @@ class Amazon:
         elif title in BUSINESS_PO_TITLES:
             self.handle_business_po()
         else:
+            log.debug(f"title is: [{title}]")
+            # see if we can handle blank titles here
+            time.sleep(
+                3
+            )  # wait a few seconds for page to load, since we don't know what we are dealing with
+            log.warning(
+                "FairGame is not sure what page it is on - will attempt to resolve."
+            )
+            ###################################################################
+            # PERFORM ELEMENT CHECKS TO SEE IF WE CAN FIGURE OUT WHERE WE ARE #
+            ###################################################################
+
+            element = None
+            # check page for order complete?
+            try:
+                element = self.driver.find_element_by_xpath(
+                    '//*[@class="a-box a-alert a-alert-success"]'
+                )
+            except sel_exceptions.NoSuchElementException:
+                pass
+            if element:
+                log.info(
+                    "FairGame thinks it completed the purchase, please verify ASAP"
+                )
+                self.send_notification(
+                    message="FairGame may have made a purchase, please confirm ASAP",
+                    page_name="unknown-title-purchase",
+                    take_screenshot=self.take_screenshots,
+                )
+                self.send_notification(
+                    message="Notifications that follow assume purchase has been made, YOU MUST CONFIRM THIS ASAP",
+                    page_name="confirm-purchase",
+                    take_screenshot=False,
+                )
+                self.handle_order_complete()
+                return
+
+            element = None
+            # Prime offer page?
+            try:
+                element = self.driver.find_element_by_xpath(
+                    '//*[contains(@class, "no-thanks-button") or contains(@class, "prime-nothanks-button") or contains(@class, "prime-no-button")]'
+                )
+            except sel_exceptions.NoSuchElementException:
+                pass
+            if element:
+                try:
+                    log.info(
+                        "FairGame thinks it is seeing a Prime Offer, attempting to click No Thanks"
+                    )
+                    element.click()
+                    self.wait_for_page_change(page_title=title)
+                    # if we were able to click, return to program flow
+                    return
+                except sel_exceptions.ElementNotInteractableException:
+                    log.debug("FairGame could not click No Thanks button")
+
+            if self.shipping_bypass:
+                element = None
+                try:
+                    element = self.driver.find_element_by_xpath(
+                        '//*[@class="ship-to-this-address a-button a-button-primary a-button-span12 a-spacing-medium  "]'
+                    )
+                except sel_exceptions.NoSuchElementException:
+                    pass
+                if element:
+                    log.warning("FairGame thinks it needs to pick a shipping address.")
+                    log.warning(
+                        "It will click whichever ship to this address button it found."
+                    )
+                    log.warning(
+                        "If this works, VERIFY THE ADDRESS IT SHIPPED TO IMMEDIATELY!"
+                    )
+                    self.send_notification(
+                        message="Clicking ship to address, hopefully this works. VERIFY ASAP!",
+                        page_name="choose-shipping",
+                        take_screenshot=self.take_screenshots,
+                    )
+                    try:
+                        element.click()
+                        log.info("Clicked button.")
+                        self.wait_for_page_change(page_title=title)
+                        return
+                    except sel_exceptions:
+                        log.error("Could not click ship to address button")
+
+            if self.get_cart_count() == 0:
+                log.info("It appears you have nothing in your cart.")
+                log.info("Returning to stock check.")
+                self.try_to_checkout = False
+                return
+
+            ##############################
+            # other element checks above #
+            ##############################
+
+            # if above checks don't work, just continue on to trying to resolve
+
+            # try to handle an unknown title
             log.error(
                 f"{title} is not a known title, please create issue indicating the title with a screenshot of page"
             )
             self.send_notification(
-                "Encountered Unknown Page Title", "unknown-title", self.take_screenshots
+                "Encountered Unknown Page Title",
+                "unknown-title",
+                self.take_screenshots,
             )
             self.save_page_source("unknown-title")
             log.info("going to try and redirect to cart page")
             try:
                 self.driver.get(AMAZON_URLS["CART_URL"])
-            except:
+            except sel_exceptions:
                 log.error(
                     "failed to load cart URL, refreshing and returning to handler"
                 )
                 self.driver.refresh()
                 time.sleep(3)
                 return
-            log.info("trying to click proceed to checkout")
             self.wait_for_page_change(page_title=title)
+            time.sleep(1)  # wait a second for page to load
+            # verify cart quantity is not zero
+            # note, not using greater than 0, in case there is an error,
+            # still want to try and proceed, if possible
+            if self.get_cart_count() == 0:
+                log.info("It appears you have nothing in your cart.")
+                log.info("Returning to stock check.")
+                self.try_to_checkout = False
+                return
+
+            log.info("trying to click proceed to checkout")
             timeout = self.get_timeout()
             button = []
             while True:
@@ -760,15 +904,43 @@ class Amazon:
                         '//*[@id="sc-buy-box-ptc-button"]'
                     )
                     break
-                except exceptions.NoSuchElementException:
+                except sel_exceptions.NoSuchElementException:
                     pass
                 if time.time() > timeout:
                     log.error(
-                        "could not find and click button, refreshing and returning to handler"
+                        "Could not find and click button, refreshing and returning to handler"
                     )
                     self.driver.refresh()
                     time.sleep(3)
                     break
+            if button:
+                try:
+                    current_title = self.driver.title
+                    log.info("Found ptc button, attempting to click.")
+                    button.click()
+                    log.info("Clicked ptc button")
+                    self.wait_for_page_change(page_title=current_title)
+                except sel_exceptions:
+                    log.info(
+                        "Could not click button - refreshing and returning to checkout handler"
+                    )
+                    self.driver.refresh()
+                    time.sleep(3)
+
+    # returns negative number if cart element does not exist, returns number if cart exists
+    def get_cart_count(self):
+        # check if cart number is on the page, if cart items = 0
+        try:
+            element = self.driver.find_element_by_xpath('//*[@id="nav-cart-count"]')
+        except sel_exceptions.NoSuchElementException:
+            return -1
+        if element:
+            try:
+                return int(element.text)
+            except Exception as e:
+                log.debug("Error converting cart number to integer")
+                log.debug(e)
+                return -1
 
     @debug
     def handle_prime_signup(self):
@@ -782,7 +954,7 @@ class Amazon:
                 # '//*[@class="a-button a-button-base no-thanks-button"]'
                 '//*[contains(@class, "no-thanks-button") or contains(@class, "prime-nothanks-button") or contains(@class, "prime-no-button")]'
             )
-        except exceptions.NoSuchElementException:
+        except sel_exceptions.NoSuchElementException:
             log.error("could not find button")
             log.info("sign up for Prime and this won't happen anymore")
             self.save_page_source("prime-signup-error")
@@ -817,7 +989,7 @@ class Amazon:
         button = None
         try:
             button = self.driver.find_element_by_xpath('//*[@id="nav-cart"]')
-        except exceptions.NoSuchElementException:
+        except sel_exceptions.NoSuchElementException:
             log.info("Could not find cart button")
         current_page = self.driver.title
         if button:
@@ -854,13 +1026,13 @@ class Amazon:
                 button = self.driver.find_element_by_xpath(
                     '//*[@id="hlb-ptc-btn-native"]'
                 )
-            except exceptions.NoSuchElementException:
+                break
+            except sel_exceptions.NoSuchElementException:
                 try:
                     button = self.driver.find_element_by_xpath('//*[@id="hlb-ptc-btn"]')
-                except exceptions.NoSuchElementException:
+                    break
+                except sel_exceptions.NoSuchElementException:
                     pass
-            if button:
-                break
             if time.time() > timeout:
                 log.info("couldn't find buttons to proceed to checkout")
                 self.save_page_source("ptc-error")
@@ -869,21 +1041,38 @@ class Amazon:
                     "ptc-error",
                     self.take_screenshots,
                 )
+                if self.get_cart_count() == 0:
+                    log.info("It appears this is because you have no items in cart.")
+                    log.info(
+                        "It is likely that the product went out of stock before you could checkout"
+                    )
+                    log.info("Going back to stock check.")
+                    self.try_to_checkout = False
+                else:
+                    log.info("Refreshing page to try again")
+                    self.driver.refresh()
+                    self.checkout_retry += 1
+                return
+
+        current_page = self.driver.title
+        if button:
+            if self.detailed:
+                self.send_notification(
+                    message="Attempting to Proceed to Checkout",
+                    page_name="ptc",
+                    take_screenshot=self.take_screenshots,
+                )
+            log.info("Found Checkout Button")
+            try:
+                button.click()
+                log.info("Clicked Proceed to Checkout Button")
+                self.wait_for_page_change(page_title=current_page)
+            except sel_exceptions:
+                log.error("Problem clicking Proceed to Checkout button.")
                 log.info("Refreshing page to try again")
                 self.driver.refresh()
+                self.wait_for_page_change(page_title=current_page)
                 self.checkout_retry += 1
-                return
-        if self.detailed:
-            self.send_notification(
-                message="Attempting to Proceed to Checkout",
-                page_name="ptc",
-                take_screenshot=self.take_screenshots,
-            )
-        current_page = self.driver.title
-        # log.info(f"time before click {time.time() - self.start_time_atc}")
-        button.click()
-        # log.info(f"time after click {time.time() - self.start_time_atc}")
-        self.wait_for_page_change(page_title=current_page)
 
     @debug
     def handle_checkout(self, test):
@@ -893,7 +1082,7 @@ class Amazon:
         while True:
             try:
                 button = self.driver.find_element_by_xpath(self.button_xpaths[0])
-            except exceptions.NoSuchElementException:
+            except sel_exceptions.NoSuchElementException:
                 pass
             self.button_xpaths.append(self.button_xpaths.pop(0))
             if button:
@@ -982,7 +1171,7 @@ class Amazon:
                     log.info("Error trying to solve captcha. Refresh and retry.")
                     self.driver.refresh()
                     time.sleep(3)
-        except exceptions.NoSuchElementException:
+        except sel_exceptions.NoSuchElementException:
             log.error("captcha page does not contain captcha element")
             log.error("refreshing")
             self.driver.refresh()
@@ -999,7 +1188,7 @@ class Amazon:
                     '//*[@id="a-autoid-0"]/span/input'
                 )
                 break
-            except exceptions.NoSuchElementException:
+            except sel_exceptions.NoSuchElementException:
                 pass
             if time.time() > timeout:
                 break
@@ -1021,7 +1210,7 @@ class Amazon:
         try:
             self.driver.save_screenshot(file_name)
             return file_name
-        except exceptions.TimeoutException:
+        except sel_exceptions.TimeoutException:
             log.info("Timed out taking screenshot, trying to continue anyway")
             pass
         except Exception as e:
@@ -1075,11 +1264,11 @@ class Amazon:
             check_cart_element = self.driver.find_element_by_xpath(
                 '//*[@id="nav-cart"]'
             )
-        except exceptions.NoSuchElementException:
+        except sel_exceptions.NoSuchElementException:
             current_page = self.driver.title
         try:
             self.driver.get(url=url)
-        except exceptions.WebDriverException or exceptions.TimeoutException:
+        except sel_exceptions.WebDriverException or sel_exceptions.TimeoutException:
             log.error(f"failed to load page at url: {url}")
             return False
         if check_cart_element:
@@ -1087,7 +1276,7 @@ class Amazon:
             while True:
                 try:
                     check_cart_element.is_displayed()
-                except exceptions.StaleElementReferenceException:
+                except sel_exceptions.StaleElementReferenceException:
                     break
                 if time.time() > timeout:
                     return False
@@ -1105,6 +1294,8 @@ class Amazon:
         log.info(f"{'=' * 50}")
         log.info(f"Starting Amazon ASIN Hunt for {len(self.asin_list)} Products with:")
         log.info(f"--Delay of {self.refresh_delay} seconds")
+        if self.headless:
+            log.info(f"--Headless doesn't work!")
         if self.used:
             log.info(f"--Used items are considered for purchase")
         if self.checkshipping:
@@ -1119,11 +1310,24 @@ class Amazon:
             )
         if self.detailed:
             log.info(f"--Detailed screenshots/notifications is enabled")
+        if self.log_stock_check:
+            log.info(f"--Additional stock check logging enabled")
         if self.testing:
             log.warning(f"--Testing Mode.  NO Purchases will be made.")
         if self.slow_mode:
-            log.warning(f"--Slow-mode enabled. Pages will fully load before execution")
-
+            log.warning(f"--Slow-mode enabled. Pages will fully load before execution.")
+        if self.shipping_bypass:
+            log.warning(f"{'=' * 50}")
+            log.warning(f"--FairGame will attempt to choose shipping address.")
+            log.warning(f"USE THIS OPTION AT YOUR OWN RISK!!!")
+            log.warning(
+                f"DO NOT COMPLAIN OR ASK FOR HELP IF BOT SHIPS TO INCORRECT ADDRESS!!!"
+            )
+            log.warning(f"Choosing payment options is not available,")
+            log.warning(
+                f"bot may still fail during checkout if defaults are not set on Amazon's site."
+            )
+            log.warning(f"{'=' * 50}")
         for idx, asins in enumerate(self.asin_list):
             log.info(
                 f"--Looking for {len(asins)} ASINs between {self.reserve_min[idx]:.2f} and {self.reserve_max[idx]:.2f}"
@@ -1174,9 +1378,13 @@ class Amazon:
             self.get_webdriver_pids()
         except Exception as e:
             log.error(e)
-            log.warning(
-                "You probably have a previous Chrome window open. You should close it"
+            log.error(
+                "If you have a JSON warning above, try deleting your .profile-amz folder"
             )
+            log.error(
+                "If that's not it, you probably have a previous Chrome window open. You should close it."
+            )
+
             return False
 
         return True

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -28,7 +28,6 @@ if os.path.isfile(LOG_FILE_PATH):
         # Eat it since it's *probably* non-fatal and since we're *probably* still able to log to the prior file
         pass
 
-
 logging.basicConfig(
     filename=LOG_FILE_PATH,
     level=logging.DEBUG,

--- a/utils/selenium_utils.py
+++ b/utils/selenium_utils.py
@@ -4,6 +4,9 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.remote.remote_connection import LOGGER as selenium_logger
+from urllib3.connectionpool import log as urllib_logger
+from logging import WARNING as logging_WARNING
 
 options = Options()
 options.add_experimental_option(
@@ -12,6 +15,8 @@ options.add_experimental_option(
 options.add_experimental_option("useAutomationExtension", False)
 # CHROME ONLY option to prevent Restore Session popup
 options.add_argument("--disable-session-crashed-bubble")
+selenium_logger.setLevel(logging_WARNING)
+urllib_logger.setLevel(logging_WARNING)
 
 
 class AnyEc:

--- a/utils/version.py
+++ b/utils/version.py
@@ -4,7 +4,7 @@ from utils.logger import log
 
 LATEST_URL = "https://api.github.com/repos/Hari-Nagarajan/fairgame/releases/latest"
 
-version = "0.5.3"
+version = "0.5.4"
 
 
 def check_version():


### PR DESCRIPTION
* fix home page handling, add wait for page change.
* reduce selenium and url lib logging to warnings only.
* add stock check logging (flag --log-stock-check
* fix captcha handling during login
* added NO_SELLERS text for amazon.es, .de, .fr, and .it
* checks cart for items before starting bot. Will not allow bot to start if there are items in cart
* added some additional handling for unknown pages. Will check elements to see if we can advance the program. Specifically, added checks for:
  * NOTE: These were only checked against smile.amazon.com
  * Purchase successful
  * Prime offer (attempt to click No Thanks)
  * Based on amazon.de page source, will click "ship to that address" button. Won't pick default payment if that is required, however. Maybe this works on other sites too?
  * Checks cart quantity and returns to stock check if 0
* fixed bug in unknown pages handling, if it finds the proceed to checkout button, it will click it.
* various readme updates
* added try/except on importing click to catch common issues related to not doing `pipenv install`

Internal
* changed selenium exceptions name from exceptions to sel_exceptions to avoid potential conflicts