### PR TITLE
Add try-catch to prevent crash when TimeoutException is thrown by wait, improve behavior when cart button not found on home page

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -1100,7 +1100,7 @@ class Amazon:
                 ):
                     return
                 else:
-                    with self.wait_for_page_content_change():
+                    with self.wait_for_page_content_change(timeout=10):
                         self.driver.refresh()
                     return
 
@@ -1110,7 +1110,7 @@ class Amazon:
             )
             self.save_page_source(page="unknown")
             self.save_screenshot(page="unknown")
-            with self.wait_for_page_content_change():
+            with self.wait_for_page_content_change(timeout=10):
                 self.driver.refresh()
             return
 
@@ -1248,10 +1248,15 @@ class Amazon:
     def handle_home_page(self):
         log.info("On home page, trying to get back to checkout")
         button = None
-        try:
-            button = self.get_amazon_element("CART_BUTTON")
-        except sel_exceptions.NoSuchElementException:
-            log.info("Could not find cart button")
+        tries = 0
+        maxTries = 10
+        while not button and tries < maxTries:
+            try:
+                button = self.get_amazon_element("CART_BUTTON")
+            except sel_exceptions.NoSuchElementException:
+                log.info("Could not find cart button")
+            tries += 1
+            sleep(0.5)
         current_page = self.driver.title
         if button:
             if self.do_button_click(button=button):

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -1100,7 +1100,7 @@ class Amazon:
                 ):
                     return
                 else:
-                    with self.wait_for_page_content_change(timeout=10):
+                    with self.wait_for_page_content_change(timeout=5):
                         self.driver.refresh()
                     return
 
@@ -1110,7 +1110,7 @@ class Amazon:
             )
             self.save_page_source(page="unknown")
             self.save_screenshot(page="unknown")
-            with self.wait_for_page_content_change(timeout=10):
+            with self.wait_for_page_content_change(timeout=5):
                 self.driver.refresh()
             return
 
@@ -1254,13 +1254,17 @@ class Amazon:
             try:
                 button = self.get_amazon_element("CART_BUTTON")
             except sel_exceptions.NoSuchElementException:
-                log.info("Could not find cart button")
+                pass
             tries += 1
             sleep(0.5)
         current_page = self.driver.title
         if button:
             if self.do_button_click(button=button):
                 return
+            else:
+                log.info("Failed to click on cart button")
+        else:
+            log.info("Could not find cart button after " + str(maxTries) + " tries")
 
         # no button found or could not interact with the button
         self.send_notification(

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -1497,10 +1497,18 @@ class Amazon:
         """Utility to help manage selenium waiting for a page to load after an action, like a click"""
         old_page = self.driver.find_element_by_tag_name("html")
         yield
-        WebDriverWait(self.driver, timeout).until(EC.staleness_of(old_page))
-        WebDriverWait(self.driver, timeout).until(
-            EC.presence_of_element_located((By.XPATH, "//title"))
-        )
+        try:
+            WebDriverWait(self.driver, timeout).until(EC.staleness_of(old_page))
+            WebDriverWait(self.driver, timeout).until(
+                EC.presence_of_element_located((By.XPATH, "//title"))
+            )
+        except sel_exceptions.TimeoutException:
+            log.info("Timed out reloading page, trying to continue anyway")
+            pass
+        except Exception as e:
+            log.error(f"Trying to recover from error: {e}")
+            pass
+        return None
 
     def wait_for_page_change(self, page_title, timeout=3):
         time_to_end = self.get_timeout(timeout=timeout)

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -1256,7 +1256,7 @@ class Amazon:
             except sel_exceptions.NoSuchElementException:
                 pass
             tries += 1
-            sleep(0.5)
+            time.sleep(0.5)
         current_page = self.driver.title
         if button:
             if self.do_button_click(button=button):

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -1100,7 +1100,7 @@ class Amazon:
                 ):
                     return
                 else:
-                    with self.wait_for_page_content_change(timeout=5):
+                    with self.wait_for_page_content_change():
                         self.driver.refresh()
                     return
 
@@ -1110,7 +1110,7 @@ class Amazon:
             )
             self.save_page_source(page="unknown")
             self.save_screenshot(page="unknown")
-            with self.wait_for_page_content_change(timeout=5):
+            with self.wait_for_page_content_change():
                 self.driver.refresh()
             return
 
@@ -1502,7 +1502,7 @@ class Amazon:
             f.write(page_source)
 
     @contextmanager
-    def wait_for_page_content_change(self, timeout=30):
+    def wait_for_page_content_change(self, timeout=5):
         """Utility to help manage selenium waiting for a page to load after an action, like a click"""
         old_page = self.driver.find_element_by_tag_name("html")
         yield


### PR DESCRIPTION
Sometimes when loading the pages with --shipping-bypass option enabled, I get a crash when the refresh step fails due to timeout. The traceback is attached: 

```
Traceback (most recent call last):
  File "app.py", line 67, in <module>
    cli.main()
  File "C:\Users\pseud\.virtualenvs\nvidia-bot-yko2BL3Q\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\pseud\.virtualenvs\nvidia-bot-yko2BL3Q\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "C:\Users\pseud\.virtualenvs\nvidia-bot-yko2BL3Q\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\pseud\.virtualenvs\nvidia-bot-yko2BL3Q\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\pseud\.virtualenvs\nvidia-bot-yko2BL3Q\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "G:\bots\nvidia-bot\cli\cli.py", line 66, in decorator
    func(*args, **kwargs)
  File "G:\bots\nvidia-bot\cli\cli.py", line 247, in amazon
    amzn_obj.run(delay=delay, test=test)
  File "G:\bots\nvidia-bot\stores\amazon.py", line 261, in run
    self.navigate_pages(test)
  File "G:\bots\nvidia-bot\utils\debugger.py", line 34, in wrapper_debug
    value = func(*args, **kwargs)
  File "G:\bots\nvidia-bot\stores\amazon.py", line 950, in navigate_pages
    self.handle_cart()
  File "G:\bots\nvidia-bot\utils\debugger.py", line 34, in wrapper_debug
    value = func(*args, **kwargs)
  File "G:\bots\nvidia-bot\stores\amazon.py", line 1336, in handle_cart
    self.driver.refresh()
  File "c:\users\pseud\appdata\local\programs\python\python38\lib\contextlib.py", line 120, in __exit__
    next(self.gen)
  File "G:\bots\nvidia-bot\stores\amazon.py", line 1501, in wait_for_page_content_change
    WebDriverWait(self.driver, timeout).until(
  File "C:\Users\pseud\.virtualenvs\nvidia-bot-yko2BL3Q\lib\site-packages\selenium\webdriver\support\wait.py", line 80, in until
    raise TimeoutException(message, screen, stacktrace)
selenium.common.exceptions.TimeoutException: Message:
```

This has been tested, when it reaches the same step in the checkout process, the line 

`2021-02-28 20:57:33|0.6.1.dev3|INFO|Timed out reloading page, trying to continue anyway`

is generated instead. 