### PR TITLE
fix version log message to run get_latest_version

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -33,7 +33,7 @@ from notifications.notifications import NotificationHandler, TIME_FORMAT
 from stores.amazon import Amazon
 from stores.bestbuy import BestBuyHandler
 from utils.logger import log
-from utils.version import is_latest, version
+from utils.version import get_latest_version, is_latest, version
 
 LICENSE_PATH = os.path.join(
     "cli",
@@ -430,7 +430,7 @@ elif version.is_prerelease:
     log.warning(f"FairGame PRE-RELEASE v{version}")
 else:
     log.warning(
-        f"You are running FairGame v{version.release}, but the most recent version is v{version.get_latest_version()}. "
+        f"You are running FairGame v{version.release}, but the most recent version is v{get_latest_version()}. "
         f"Consider upgrading "
     )
 


### PR DESCRIPTION
fixes this
```
Traceback (most recent call last):                                    
  File "app.py", line 51, in <module>                                      
    from cli import cli                                                    
  File "/home/fairgame/fairgame3/cli/cli.py", line 345, in <module>                                             
    f"You are running FairGame v{version.release}, but the most recent version is v{version.get_latest_version()
}. 
```