### PR TITLE
fix: adds German 2FA title to config

### DIFF
--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -150,7 +150,8 @@
     "SHIPPING_ONLY_IF": "FREE Shipping on orders over",
     "TWOFA_TITLES": [
       "Two-Step Verification",
-      "Verifica in due fasi"
+      "Verifica in due fasi",
+      "Zwei-Schritt-Verifizierung"
     ],
     "PRIME_TITLES": [
       "Complete your Amazon Prime sign up"


### PR DESCRIPTION
This helps fairgame to identify the German OTP page:
![screenshot-Start-Up_03-27-2021_13_50_42 1](https://user-images.githubusercontent.com/838003/112723073-b7218300-8f04-11eb-906d-bb1832b38400.png)
