### PR TITLE
feat: adds more 2FA titles

### DIFF
--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -157,7 +157,9 @@
       "Weryfikacja dwuetapowa",
       "Tvåstegsverifiering",
       "İki Adımlı Doğrulama",
-      "Verificatie in twee stappen"
+      "Verificatie in twee stappen",
+      "Verificação em Duas Etapas",
+      "Verificação de dois passos"
     ],
     "PRIME_TITLES": [
       "Complete your Amazon Prime sign up"

--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -151,7 +151,13 @@
     "TWOFA_TITLES": [
       "Two-Step Verification",
       "Verifica in due fasi",
-      "Zwei-Schritt-Verifizierung"
+      "Zwei-Schritt-Verifizierung",
+      "Vérification en deux étapes",
+      "Verificación en dos pasos",
+      "Weryfikacja dwuetapowa",
+      "Tvåstegsverifiering",
+      "İki Adımlı Doğrulama",
+      "Verificatie in twee stappen"
     ],
     "PRIME_TITLES": [
       "Complete your Amazon Prime sign up"


### PR DESCRIPTION
This adds support for the 2FA titles of the following Amazon countries:
- Poland
- Sweden
- Turkey
- Netherlands
- Spain
- France