### PR TITLE
Automatically accept cookies

### DIFF
--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -557,6 +557,13 @@ class Amazon:
                     if open_offers_link:
                         log.debug("Attempting to click the open offers link...")
                         try:
+                         cookie_button = self.driver.find_element_by_xpath("//input[@id='sp-cc-accept']")
+                        except:
+                         cookie_button = None
+                        if cookie_button:
+                         cookie_button.click()
+                         log.info("Cookies accepted!")
+                        try:
                             open_offers_link.click()
                         except sel_exceptions.WebDriverException as e:
                             log.error("Problem clicking open offers link")


### PR DESCRIPTION
This is very useful in the cases where the bot gets stuck because it gets asked to accept cookies from Amazon. I accepted them manually multiple times but sometimes I get asked again. I implemented this fix and noticed it accepts cookies sometimes almost once every hour.