### PR TITLE
fix: merchant regex

### DIFF
--- a/stores/amazon_requests.py
+++ b/stores/amazon_requests.py
@@ -888,7 +888,7 @@ class AmazonStoreHandler(BaseStoreHandler):
                         0
                     ].value
                 except IndexError:
-                    find_merchant_id = re.search(r"merchantId = \"(.*?)\";", payload)
+                    find_merchant_id = re.search(r"merchantId = \"(\w+?)\";", payload)
                     if find_merchant_id:
                         merchant_id = find_merchant_id.group(1)
                     else:


### PR DESCRIPTION
otherwise the first empty `merchantId = ""` is selected otherwise and the merchant hurdle fails