### PR TITLE
Bugfixes: Headless Window Size, Reserve Price, Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ html_saves/*.html
 screenshots/*.png
 logs/*.log*
 tags
+.venv*

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,8 @@
 .profile
 .profile-amz*
 .vscode/
-/config/*_credentials.json
+/config/*.json
 /config/apprise.conf
-/config/apprise_config.json
 Pipfile.lock
 __pycache__/
 build/
@@ -21,3 +20,4 @@ geckodriver.log
 html_saves/*.html
 screenshots/*.png
 logs/*.log*
+tags

--- a/__INSTALL (RUN FIRST).bat
+++ b/__INSTALL (RUN FIRST).bat
@@ -1,6 +1,7 @@
 @echo on
 pip install pipenv
 pause
+set PIPENV_VENV_IN_PROJECT=1
 pipenv install
 
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -63,9 +63,11 @@ def notify_on_crash(func):
     def decorator(*args, **kwargs):
         try:
             func(*args, **kwargs)
+
         except KeyboardInterrupt:
-            log.info("Caught Ctrl-C - Exiting...")
+            log.info("Caught ctrl-c; Exiting...")
             return
+
         except:
             notification_handler.send_notification(f"FairGame has crashed.")
             raise

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -68,9 +68,9 @@ def notify_on_crash(func):
             log.info("Caught ctrl-c; Exiting...")
             return
 
-        except:
+        except Exception as e:
+            log.debug(e)
             notification_handler.send_notification(f"FairGame has crashed.")
-            raise
 
     return decorator
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -64,8 +64,9 @@ def notify_on_crash(func):
         try:
             func(*args, **kwargs)
         except KeyboardInterrupt:
-            pass
-        else:
+            log.info("Caught Ctrl-C - Exiting...")
+            return
+        except:
             notification_handler.send_notification(f"FairGame has crashed.")
             raise
 

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -65,8 +65,7 @@ def notify_on_crash(func):
             func(*args, **kwargs)
 
         except KeyboardInterrupt:
-            log.info("Caught ctrl-c; Exiting...")
-            return
+            pass
 
         except Exception as e:
             log.debug(e)

--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -99,6 +99,11 @@
     "CHECKOUT_TITLES": [
       "Amazon.com Checkout",
       "Amazon.co.uk Checkout",
+      "Amazon.ca Checkout",
+      "Amazon.es Checkout",
+      "Amazon.de Checkout",
+      "Amazon.fr Checkout",
+      "Amazon.it Checkout",
       "Place Your Order - Amazon.ca Checkout",
       "Place Your Order - Amazon.co.uk Checkout",
       "Amazon.de Checkout",
@@ -165,7 +170,14 @@
       "Complete your Amazon Prime sign up"
     ],
     "OUT_OF_STOCK": [
-      "Out of Stock - AmazonSmile Checkout"
+      "Out of Stock - AmazonSmile Checkout",
+      "Out of Stock - Amazon.com Checkout",
+      "Out of Stock - Amazon.ca Checkout",
+      "Out of Stock - Amazon.de Checkout",
+      "Out of Stock - Amazon.fr Checkout",
+      "Out of Stock - Amazon.co.uk Checkout",
+      "Out of Stock - Amazon.es Checkout",
+      "Out of Stock - Amazon.it Checkout"
     ],
     "NO_SELLERS": [
       "Currently, there are no sellers that can deliver this item to your location.",

--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -232,6 +232,9 @@
       ],
       "ATC": [
         "//div[@id='aod-pinned-offer' or @id='aod-offer' or @id='olpOfferList']//input[@name='submit.addToCart']"
+      ],
+      "ATC_BUY_BOX":[
+        "//div[@id='qualifiedBuybox']//input[@id='add-to-cart-button']"
       ]
     }
   }

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -666,12 +666,12 @@ class Amazon:
                 )
 
             except sel_exceptions.TimeoutException as te:
-                log.error("Timed out waiting for offers to render.  Skipping...")
-                log.error(f"URL: {self.driver.current_url}")
-                log.exception(te)
+                log.warning("Timed out waiting for offers to render.  Skipping...")
+                log.warning(f"URL: {self.driver.current_url}")
+                log.debug(te)
                 return False
             except sel_exceptions.NoSuchElementException:
-                log.error("Unable to find any offers listing.  Skipping...")
+                log.warning("Unable to find any offers listing.  Skipping...")
                 return False
             except sel_exceptions.ElementClickInterceptedException as e:
                 log.debug(

--- a/stores/amazon.py
+++ b/stores/amazon.py
@@ -757,9 +757,8 @@ class Amazon:
             (ship_float + price_float) >= reserve_min
             or math.isclose((price_float + ship_float), reserve_min, abs_tol=0.01)
         ):
-            log.info(f"Item {asin} in stock and in reserve range!")
-            log.debug(
-                f"{reserve_min} <= {price_float} + {ship_float} shipping <= {reserve_max}"
+            log.info(
+                f"Item {asin} in stock and in reserve range: {price_float} + {ship_float} shipping <= {reserve_max}"
             )
             log.info("Adding to cart")
             # Get the offering ID

--- a/utils/selenium_utils.py
+++ b/utils/selenium_utils.py
@@ -156,3 +156,4 @@ def enable_headless():
     options.add_argument("--window-size=1920x1080")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")

--- a/utils/selenium_utils.py
+++ b/utils/selenium_utils.py
@@ -153,5 +153,6 @@ def add_cookies_to_session_from_driver(driver, session):
 
 def enable_headless():
     options.add_argument("--headless")
+    options.add_argument("--window-size=1920x1080")
     options.add_argument("--no-sandbox")
     options.add_argument("--disable-dev-shm-usage")

--- a/utils/version.py
+++ b/utils/version.py
@@ -27,7 +27,7 @@ _LATEST_URL = "https://api.github.com/repos/Hari-Nagarajan/fairgame/releases/lat
 # See https://www.python.org/dev/peps/pep-0440/ for specification
 # See https://www.python.org/dev/peps/pep-0440/#examples-of-compliant-version-schemes for examples
 
-__VERSION = "0.6.2"
+__VERSION = "0.6.3"
 version = Version(__VERSION)
 
 


### PR DESCRIPTION
Fixing some things that I found:

Adding validation to min/max price and improved logging when an offer price falls outside the reserve (many questions pop up on Discord concerning this type of silent failure).

Changed the log-level of several error conditions to warning/error instead of info.

Added window-size option for headless operation. The default might make for unusable screenshots

Updated `.gitignore` to ignore all `.json` files in config and the `tags` file for `ctags` users

Improved tracking of the check/cart time

Changed crash report to only trigger for unhandled exceptions and allow for error-free return on sucess or on `ctrl-c`