### PR TITLE
Handle simple OTP case via CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .profile
 .profile-amz*
 .vscode/
-/config/*_credentials.json
+/config/*.json
 /config/apprise.conf
 /config/apprise_config.json
 Pipfile.lock
@@ -21,3 +21,5 @@ geckodriver.log
 html_saves/*.html
 screenshots/*.png
 logs/*.log*
+tags
+stores/store_data/item_cache.p

--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -298,6 +298,12 @@
       ],
       "PASSWORD_TEXT_FIELD":[
         "//*[@id='ap_password']"
+      ],
+      "OTP_FIELD":[
+        '//*[@id="auth-mfa-otpcode"]'
+      ],
+      "OTP_REMEMBER_ME":[
+        '//*[@name="rememberDevice"]'
       ]
     }
   }


### PR DESCRIPTION
When the account is configured with a single, preferred 2FA option,
prompt the user for a code and click the "Remember Me" checkbox to
prevent 2FA from popping up on this profile again.

For some 2FA configurations the old message to enter the code in the
browser will pop-up as a fallback

Add Xpath entries to `config/fairgame.conf` for OTP elements

Update .gitignore to ignore all `*.json` in `config`, `tags`, and the
item_store pickle file

Fix bad reference to `self.get_timeout()` which doesn't exist anymore