### PR TITLE
fix(asin): expand regex to find correct/first product ASIN

### DIFF
--- a/stores/amazon_requests.py
+++ b/stores/amazon_requests.py
@@ -900,7 +900,7 @@ class AmazonStoreHandler(BaseStoreHandler):
             except (AttributeError, IndexError):
                 found_asin = "[NO ASIN FOUND ON PAGE]"
         else:
-            find_asin = re.search(r"asin = \"(.*?)\"", payload)
+            find_asin = re.search(r"asin\s?(?:=|\.)?\s?\"?([A-Z0-9]+)\"?", payload)
             if find_asin:
                 found_asin = find_asin.group(1)
             else:


### PR DESCRIPTION
For EU there is no such thing as `asin = ""`. Rather, it's hidden in some inputs like ``<input type="hidden" name="metric-asin.B07L9BDY3T" value="1"/>`
This regex catches both now.