### PR TITLE
Update debugger.py to fix character encoding error

### DIFF
--- a/utils/debugger.py
+++ b/utils/debugger.py
@@ -35,7 +35,7 @@ def debug(func):
         start_time = time.time()
         value = func(*args, **kwargs)
         log.debug(
-            f"{func.__name__!r} returned {value!r}. Function ran for {time.time()-start_time} seconds."
+            f"{func.__name__!r} returned {value!r}. Function ran for {time.time()-start_time} seconds.".encode("utf-8")
         )  # 4
         return value
 


### PR DESCRIPTION
Fix barfing when html contains unicode characters which cannot be displayed by the system default charset (I'm on win10). 

Example for a scalper's page https://www.amazon.com/dp/B08LF1CWT2/ (relevant excerpts)

`UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4a3' in position 26346: character maps to <undefined>`

`\utils\debugger.py", line 37, in wrapper_debug`