### PR TITLE
Fix 403 error by using session id in CSRF token

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -95,10 +95,16 @@ def main():
 
 
 @click.command()
+@click.option(
+    "--p",
+    type=str,
+    default=None,
+    help="Pass in encryption file password as argument",
+)
 @notify_on_crash
-def amazon_aio():
+def amazon_aio(p):
     log.debug("Creating AIO Amazon Store Handler")
-    aio_amazon_obj = AIO_AmazonStoreHandler(notification_handler=notification_handler)
+    aio_amazon_obj = AIO_AmazonStoreHandler(notification_handler=notification_handler, encryption_pass=p)
     global tasks
     log.debug("Creating AIO Amazon Store Tasks")
     tasks = asyncio.run(aio_amazon_obj.run_async())

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -104,7 +104,9 @@ def main():
 @notify_on_crash
 def amazon_aio(p):
     log.debug("Creating AIO Amazon Store Handler")
-    aio_amazon_obj = AIO_AmazonStoreHandler(notification_handler=notification_handler, encryption_pass=p)
+    aio_amazon_obj = AIO_AmazonStoreHandler(
+        notification_handler=notification_handler, encryption_pass=p
+    )
     global tasks
     log.debug("Creating AIO Amazon Store Tasks")
     tasks = asyncio.run(aio_amazon_obj.run_async())

--- a/common/amazon_support.py
+++ b/common/amazon_support.py
@@ -120,6 +120,7 @@ class FGItem:
     id: str
     min_price: Price
     max_price: Price
+    purchase_delay: int = 0
     name: str = None
     short_name: str = None
     furl: furl = None

--- a/stores/amazon_checkout.py
+++ b/stores/amazon_checkout.py
@@ -132,7 +132,9 @@ class AmazonCheckoutHandler(BaseStoreHandler):
         self.time_interval = timer
         self.cookie_list = cookie_list
 
-        self.checkout_session: aiohttp.ClientSession = aiohttp.ClientSession(headers=HEADERS)
+        self.checkout_session: aiohttp.ClientSession = aiohttp.ClientSession(
+            headers=HEADERS
+        )
 
     def pull_cookies(self):
         # Spawn the web browser
@@ -405,8 +407,8 @@ class AmazonCheckoutHandler(BaseStoreHandler):
         log.debug("Cookies from Selenium:")
         for cookie in cookies:
             log.debug(f"{cookie}: {cookies[cookie]}")
-        if session_id := cookies.get('session-id'):
-            self.checkout_session.headers['x-amz-checkout-csrf-token'] = session_id
+        if session_id := cookies.get("session-id"):
+            self.checkout_session.headers["x-amz-checkout-csrf-token"] = session_id
         self.checkout_session.cookie_jar.update_cookies(cookies)
         # It appears the amazon session is valid for 366 days.
         domain = "smile.amazon.com"
@@ -430,7 +432,9 @@ class AmazonCheckoutHandler(BaseStoreHandler):
                 )
                 retry += 1
             if pid and anti_csrf:
-                if await turbo_checkout(s=self.checkout_session, pid=pid, anti_csrf=anti_csrf):
+                if await turbo_checkout(
+                    s=self.checkout_session, pid=pid, anti_csrf=anti_csrf
+                ):
                     log.info("Maybe completed checkout")
                     time_difference = time.time() - start_time
                     log.info(

--- a/stores/amazon_checkout.py
+++ b/stores/amazon_checkout.py
@@ -91,7 +91,7 @@ AMAZON_URLS = {
 }
 
 PDP_PATH = "/dp/"
-REALTIME_INVENTORY_PATH = f"gp/aod/ajax?asin="
+REALTIME_INVENTORY_PATH = "gp/aod/ajax?asin="
 
 CONFIG_FILE_PATH = "config/amazon_requests_config.json"
 STORE_NAME = "Amazon"

--- a/stores/amazon_checkout.py
+++ b/stores/amazon_checkout.py
@@ -90,7 +90,7 @@ AMAZON_URLS = {
     "PYO_POST": "https://{domain}/gp/buy/spc/handlers/static-submit-decoupled.html/ref=ox_spc_place_order?",
 }
 
-PDP_PATH = f"/dp/"
+PDP_PATH = "/dp/"
 REALTIME_INVENTORY_PATH = f"gp/aod/ajax?asin="
 
 CONFIG_FILE_PATH = "config/amazon_requests_config.json"

--- a/stores/amazon_handler.py
+++ b/stores/amazon_handler.py
@@ -107,6 +107,7 @@ class AmazonStoreHandler(BaseStoreHandler):
             future[idx].add_done_callback(recreate_session_callback)
 
         await asyncio.gather(
+            amazon_checkout.refresh_session(interval=3500), # wild guess that sessions are good for an hour
             amazon_checkout.checkout_worker(queue=queue),
             *[
                 amazon_monitoring.sessions_list[idx].stock_check(queue, future[idx])

--- a/stores/amazon_handler.py
+++ b/stores/amazon_handler.py
@@ -57,7 +57,6 @@ class AmazonStoreHandler(BaseStoreHandler):
         self.amazon_domain = "smile.amazon.com"
         self.webdriver_child_pids = []
         self.single_shot = single_shot
-        # self.loop = asyncio.get_event_loop()
 
         from cli.cli import global_config
 
@@ -107,7 +106,6 @@ class AmazonStoreHandler(BaseStoreHandler):
             future[idx].add_done_callback(recreate_session_callback)
 
         await asyncio.gather(
-            amazon_checkout.refresh_session(interval=3500),  # wild guess that sessions are good for an hour
             amazon_checkout.checkout_worker(queue=queue),
             *[
                 amazon_monitoring.sessions_list[idx].stock_check(queue, future[idx])

--- a/stores/amazon_handler.py
+++ b/stores/amazon_handler.py
@@ -107,7 +107,7 @@ class AmazonStoreHandler(BaseStoreHandler):
             future[idx].add_done_callback(recreate_session_callback)
 
         await asyncio.gather(
-            amazon_checkout.refresh_session(interval=3500), # wild guess that sessions are good for an hour
+            amazon_checkout.refresh_session(interval=3500),  # wild guess that sessions are good for an hour
             amazon_checkout.checkout_worker(queue=queue),
             *[
                 amazon_monitoring.sessions_list[idx].stock_check(queue, future[idx])
@@ -176,6 +176,7 @@ class AmazonStoreHandler(BaseStoreHandler):
                             asin,
                             min_price,
                             max_price,
+                            purchase_delay=json_item.get("purchase_delay", 0),
                             condition=condition,
                             merchant_id=merchant_id,
                             furl=furl(

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -178,6 +178,9 @@ class AmazonMonitor(aiohttp.ClientSession):
         self.domain = urlparse(self.item.furl.url).netloc
 
         self.delay: float = 5
+        if item.purchase_delay > 0:
+            self.delay = 20
+        self.block_purchase_until = time.time() + item.purchase_delay
         log.debug("Initializing Monitoring Task")
 
     def assign_config(self, azn_config):
@@ -260,11 +263,14 @@ class AmazonMonitor(aiohttp.ClientSession):
                     )
                     if qualified_seller:
                         log.debug("Found an offer which meets criteria")
-                        await queue.put(qualified_seller)
-                        log.debug("Offer placed in queue")
-                        log.debug("Quitting monitoring task")
-                        future.set_result(None)
-                        return None
+                        if (time.time() > self.block_purchase_until):
+                            await queue.put(qualified_seller)
+                            log.debug("Offer placed in queue")
+                            log.debug("Quitting monitoring task")
+                            future.set_result(None)
+                            return None
+                        else:
+                            log.debug(f"Purchasing is blocked until {self.block_purchase_until}. It is now {time.time()}.")
             # failed to find seller. Wait a delay period then check again
             log.debug("No offers found which meet product criteria")
             await wait_timer(end_time)
@@ -281,7 +287,6 @@ class AmazonMonitor(aiohttp.ClientSession):
             check_count += 1
 
     async def aio_get(self, url):
-        status = 404
         text = None
         try:
             async with self.get(url) as resp:

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -209,7 +209,7 @@ class AmazonMonitor(aiohttp.ClientSession):
         log.debug(f"Monitoring Task Started for {self.item.id}")
 
         fail_counter = 0  # Count sequential get fails
-        delay = 5
+        delay = self.delay
         end_time = time.time() + delay
         status, response_text = await self.aio_get(url=self.item.furl.url)
 

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -89,7 +89,7 @@ AMAZON_URLS = {
 }
 
 PDP_PATH = "/dp/"
-REALTIME_INVENTORY_PATH = f"gp/aod/ajax?asin="
+REALTIME_INVENTORY_PATH = "gp/aod/ajax?asin="
 
 CONFIG_FILE_PATH = "config/amazon_requests_config.json"
 PROXY_FILE_PATH = "config/proxies.json"

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -263,14 +263,16 @@ class AmazonMonitor(aiohttp.ClientSession):
                     )
                     if qualified_seller:
                         log.debug("Found an offer which meets criteria")
-                        if (time.time() > self.block_purchase_until):
+                        if time.time() > self.block_purchase_until:
                             await queue.put(qualified_seller)
                             log.debug("Offer placed in queue")
                             log.debug("Quitting monitoring task")
                             future.set_result(None)
                             return None
                         else:
-                            log.debug(f"Purchasing is blocked until {self.block_purchase_until}. It is now {time.time()}.")
+                            log.debug(
+                                f"Purchasing is blocked until {self.block_purchase_until}. It is now {time.time()}."
+                            )
             # failed to find seller. Wait a delay period then check again
             log.debug("No offers found which meet product criteria")
             await wait_timer(end_time)

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -88,7 +88,7 @@ AMAZON_URLS = {
     "PYO_POST": "https://{domain}/gp/buy/spc/handlers/static-submit-decoupled.html/ref=ox_spc_place_order?",
 }
 
-PDP_PATH = f"/dp/"
+PDP_PATH = "/dp/"
 REALTIME_INVENTORY_PATH = f"gp/aod/ajax?asin="
 
 CONFIG_FILE_PATH = "config/amazon_requests_config.json"

--- a/utils/selenium_utils.py
+++ b/utils/selenium_utils.py
@@ -169,9 +169,13 @@ def disable_gpu():
 
 def get_cookies(d: webdriver.Chrome, cookie_list=None):
     cookies = {}
-    for c in d.get_cookies():
+    selenium_cookies = d.get_cookies()
+    for c in selenium_cookies:
         if cookie_list is None or c["name"] in cookie_list:
             cookies[c["name"]] = c["value"]
+    expiration = min(map(lambda c: c['expiry'], selenium_cookies))
+    # It appears that for the session cookies, they don't expire for an entire year. So we don't need to do anything
+    # with the expiration time.
     return cookies
 
 

--- a/utils/selenium_utils.py
+++ b/utils/selenium_utils.py
@@ -173,7 +173,7 @@ def get_cookies(d: webdriver.Chrome, cookie_list=None):
     for c in selenium_cookies:
         if cookie_list is None or c["name"] in cookie_list:
             cookies[c["name"]] = c["value"]
-    expiration = min(map(lambda c: c['expiry'], selenium_cookies))
+    expiration = min(map(lambda c: c["expiry"], selenium_cookies))
     # It appears that for the session cookies, they don't expire for an entire year. So we don't need to do anything
     # with the expiration time.
     return cookies


### PR DESCRIPTION
When I tested using an item that was in stock, checkout worked fine. But when the item I was actually looking for came into stock (several hours after I'd started running fairgame), I got a 403 response to the turbo_initiate call. 

My thinking is that perhaps that 403 is from the session cookies having expired, so I wrote this code to refresh them.