### PR TITLE
Added WindowsSelectorEventLoopPolicy for proxy support

### DIFF
--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -19,6 +19,7 @@
 
 import json
 import os
+import platform
 
 import time
 import typing
@@ -60,6 +61,10 @@ from utils.logger import log
 import asyncio
 import aiohttp
 from aiohttp_proxy import ProxyConnector, ProxyType
+
+if platform.system() == "Windows":
+    policy = asyncio.WindowsSelectorEventLoopPolicy()
+    asyncio.set_event_loop_policy(policy)
 
 # PDP_URL = "https://smile.amazon.com/gp/product/"
 # AMAZON_DOMAIN = "www.amazon.com.au"


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-policy.html

According to asyncio docs the default policy uses ProactorEventLoop which seems to cause proxies to not work on Windows. Switching it to SelectorEventLoop using `asyncio.WindowsSelectorEventLoopPolicy()` fixes the issue.

If you don't add this code using Windows and try to run proxies it will not work and you will get an SSL error.

Credit goes to TehMadDog on Discord for finding the fix, I just added the if statement to check if the user is on Windows before applying it.