### PR TITLE
Random Proxy Rotation

### DIFF
--- a/config/proxies.template_json
+++ b/config/proxies.template_json
@@ -1,12 +1,8 @@
 {
     "proxies": [
-        {
-            "http": "http://user:password@ipaddress:port",
-            "https": "http://user:password@ipaddress:port"
-        },
-        {
-            "http": "http://user:password@ipaddress:port",
-            "https": "http://user:password@ipaddress:port"
-        }
+            "http://user:password@ipaddress:port",
+            "http://user:password@ipaddress:port"
+            "http://user:password@ipaddress:port",
+            "http://user:password@ipaddress:port"
     ]
 }

--- a/stores/amazon_checkout.py
+++ b/stores/amazon_checkout.py
@@ -76,6 +76,7 @@ from utils.misc import (
     save_html_response,
     get_timestamp_filename,
     get_webdriver_pids,
+    response_counter,
 )
 
 from functools import wraps
@@ -414,7 +415,8 @@ class AmazonCheckoutHandler(BaseStoreHandler):
         domain = "smile.amazon.com"
         resp = await self.checkout_session.get(f"https://{domain}")
         html_text = await resp.text()
-        save_html_response("session-get", resp.status, html_text)
+        # save_html_response("session-get", resp.status, html_text)
+        response_counter(resp.status)
         while True:
             log.debug("Checkout task waiting for item in queue")
             qualified_seller = await queue.get()
@@ -445,7 +447,8 @@ class AmazonCheckoutHandler(BaseStoreHandler):
                             self.checkout_session,
                             f"https://{domain}/gp/buy/thankyou/handlers/display.html?_from=cheetah&checkMFA=1&purchaseId={pid}&referrer=yield&pid={pid}&pipelineType=turbo&clientId=retailwebsite&temporaryAddToCart=1&hostPage=detail&weblab=RCX_CHECKOUT_TURBO_DESKTOP_PRIME_87783",
                         )
-                        save_html_response("order-confirm", status, text)
+                        # save_html_response("order-confirm", status, text)
+                        response_counter(status)
                     except aiohttp.ClientError:
                         log.debug("could not save order confirmation page")
                     await self.checkout_session.close()
@@ -514,6 +517,7 @@ async def turbo_initiate(
     captcha_element = True  # to initialize loop
     status, text = await aio_post(client=s, url=url, data=payload_inputs)
     save_html_response("turbo-initiate", status, text)
+    response_counter(777)
     tree: Optional[html.HtmlElement] = None
     while retry < MAX_RETRY and captcha_element:
         tree = check_response(text)

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -166,7 +166,7 @@ class AmazonMonitoringHandler(BaseStoreHandler):
         for idx in range(self.proxies_length):
             AmazonMonitor.proxies.update({idx: {self.proxies[idx]: time.time()}})
             log.debug(f"Adding [{self.proxies[idx]}] to the pool")
-        AmazonMonitor.proxies_length = len(self.proxies)
+        AmazonMonitor.proxies_length = self.proxies_length
 
 
 # class Offers(NamedTuple):

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -230,7 +230,6 @@ class AmazonMonitor(aiohttp.ClientSession):
     def get_new_proxy(self):
         while True:
             rand_num = randint(0, self.proxies_length - 1)
-            print(rand_num)
             proxy_t = self.proxies[rand_num]
             for proxy, t in proxy_t.items():
                 if time.time() - t >= 6:

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -225,17 +225,15 @@ class AmazonMonitor(aiohttp.ClientSession):
         log.debug("Sesssion Created")
         return session
 
-    def get_new_proxy(self):
+    async def get_new_proxy(self):
         while True:
             rand_num = randint(0, len(self.connectors) - 1)
             conn_t = self.connectors[rand_num]
             for conn, t in conn_t.items():
-                if time.time() - t >= self.delay:
+                if time.time() - t >= 6:
                     self.connectors[rand_num].update({conn: time.time()})
                     old_connector = self.connector
-                    self.connector = conn
-                    log.debug(f'{self.item.id}: Switching from [{old_connector.proxy_url}] to [{self.connector.proxy_url}]')
-                    return None
+                    return old_connector, conn
             else:
                 log.debug("Trying again to grab available proxy...")
   
@@ -331,7 +329,8 @@ class AmazonMonitor(aiohttp.ClientSession):
 
             check_count += 1
 
-            self.get_new_proxy()
+            conns = await self.get_new_proxy()
+            log.debug(f'{self.item.id}: Switching from [{conns[0].proxy_url}] to [{conns[1].proxy_url}]')
 
 
     async def aio_get(self, url):

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -253,7 +253,6 @@ class AmazonMonitor(aiohttp.ClientSession):
 
 
     async def stock_check(self, queue: asyncio.Queue, future: asyncio.Future):
-        pprint(self.proxies)
         # Do first response outside of while loop, so we can continue on captcha checks
         # and return to start of while loop with that response. Requires the next response
         # to be grabbed at end of while loop

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -42,6 +42,7 @@ from utils.misc import (
     get_timestamp_filename,
     save_html_response,
     check_response,
+    response_counter,
 )
 
 from common.amazon_support import (
@@ -255,7 +256,8 @@ class AmazonMonitor(aiohttp.ClientSession):
         end_time = time.time() + delay
         status, response_text = await self.aio_get(url=self.item.furl.url)
 
-        save_html_response("stock-check", status, response_text)
+        # save_html_response("stock-check", status, response_text)
+        response_counter(status)
 
         # do this after each request
         fail_counter = check_fail(status=status, fail_counter=fail_counter)
@@ -317,7 +319,8 @@ class AmazonMonitor(aiohttp.ClientSession):
             await wait_timer(end_time)
             end_time = time.time() + delay
             status, response_text = await self.aio_get(url=self.item.furl.url)
-            save_html_response("stock-check", status, response_text)
+            # save_html_response("stock-check", status, response_text)
+            # response_counter(status)
             # do this after each request
             fail_counter = check_fail(status=status, fail_counter=fail_counter)
             if fail_counter == -1:

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -236,6 +236,7 @@ class AmazonMonitor(aiohttp.ClientSession):
                     return old_connector, conn
             else:
                 log.debug("Trying again to grab available proxy...")
+                await asyncio.sleep(1)
   
     @property
     def connector(self):

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -235,8 +235,7 @@ class AmazonMonitor(aiohttp.ClientSession):
                     old_connector = self.connector
                     return old_connector, conn
             else:
-                log.debug("Trying again to grab available proxy...")
-                await asyncio.sleep(1)
+                continue
   
     @property
     def connector(self):

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -230,12 +230,10 @@ class AmazonMonitor(aiohttp.ClientSession):
             rand_num = randint(0, len(self.connectors) - 1)
             conn_t = self.connectors[rand_num]
             for conn, t in conn_t.items():
-                if time.time() - t >= 6:
+                if time.time() - t >= 7:
                     self.connectors[rand_num].update({conn: time.time()})
                     old_connector = self.connector
                     return old_connector, conn
-            else:
-                continue
   
     @property
     def connector(self):
@@ -330,6 +328,7 @@ class AmazonMonitor(aiohttp.ClientSession):
             check_count += 1
 
             conns = await self.get_new_proxy()
+            self.connector = conns[1]
             log.debug(f'{self.item.id}: Switching from [{conns[0].proxy_url}] to [{conns[1].proxy_url}]')
 
 

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -22,6 +22,7 @@ import os
 import aiohttp
 from typing import Optional, List
 
+import json
 
 import time
 from datetime import datetime
@@ -148,3 +149,29 @@ def parse_html_source(data):
     except html.etree.ParserError:
         log.debug("html parser error")
     return tree
+
+def response_counter(status):
+    RESPONSE_COUNTER_PATH = "html_saves/response_counter.json"
+    if os.path.exists(RESPONSE_COUNTER_PATH):
+        with open(RESPONSE_COUNTER_PATH, "r") as f:
+            counter = json.load(f)
+    else:
+        counter = {"200" : 0,
+                   "403" : 0,
+                   "503" : 0,
+                   "999" : 0,
+                   "turbo": 0} 
+
+    if status == 200:
+        counter["200"] += 1
+    if status == 403:
+        counter["403"] += 1
+    if status == 503:
+        counter["503"] += 1
+    if status == 999:
+        counter["999"] += 1
+    if status == 777:
+        counter["turbo"] += 1
+
+    with open(RESPONSE_COUNTER_PATH, "w") as f:
+        json.dump(counter, f, indent=4)


### PR DESCRIPTION
Tried adding random rotation to the proxies.

Changed the format of proxies.json to just a list to simplify for myself.

In AmazonMonitoringHandler's init, each proxy is placed in a nested dictionary with the idx number as the parent key and the inner dict holding proxy as key and time.time() as value.
eg) {31: {user:pw@ip:port : time.time()}}

The function AmazonMonitor.get_new_proxy() is ran in each stock_check function where it uses randint to generate a number between 0 and (number of proxies - 1), which is used to call the dictionary holding the respective proxy address and the last time it was used. All of this is in a while loop that breaks when the condition that the last access time of the time value is greater than 6 seconds.

It's mega clunky and I still don't have a very clear idea how async works and would love some advices to improve or change the design of this. Thanks.