### PR TITLE
fix: ignore Windows shortcuts (.lnk files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ screenshots/*.png
 logs/*.log*
 tags
 .venv*
+.lnk


### PR DESCRIPTION
I keep a list of shortcuts which launch the Chrome profile FG uses, but those should not belong to the Git