### PR TITLE
feat: use amazon domain from config file again

### DIFF
--- a/stores/amazon_checkout.py
+++ b/stores/amazon_checkout.py
@@ -117,6 +117,7 @@ class AmazonCheckoutHandler(BaseStoreHandler):
         password=None,
         timer=7200,
         cookie_list=None,
+        amazon_domain="smile.amazon.com",
     ):
         log.debug("Initializing AmazonCheckoutHandler")
         self.profile_path = profile_path
@@ -125,6 +126,7 @@ class AmazonCheckoutHandler(BaseStoreHandler):
             enable_headless()
         self.amazon_config = amazon_config
         self.notification_handler = notification_handler
+        self.amazon_domain = amazon_domain
 
         # Selenium setup
         selenium_initialization(options=options, profile_path=self.profile_path)
@@ -150,16 +152,21 @@ class AmazonCheckoutHandler(BaseStoreHandler):
         return cookies
 
     def login(self):
-        domain = "smile.amazon.com"
-        log.info(f"Logging in to {domain}...")
-
-        amazonsmile_url = "https://smile.amazon.com/ap/signin/ref=smi_ge2_ul_si_rl?_encoding=UTF8&ie=UTF8&openid.assoc_handle=amzn_smile&openid.claimed_id=http://specs.openid.net/auth/2.0/identifier_select&openid.identity=http://specs.openid.net/auth/2.0/identifier_select&openid.mode=checkid_setup&openid.ns=http://specs.openid.net/auth/2.0&openid.ns.pape=http://specs.openid.net/extensions/pape/1.0&openid.pape.max_auth_age=0&openid.return_to=https://smile.amazon.com/gp/charity/homepage.html?ie=UTF8&newts=1&orig=%2F"
-        amazoncom_url = "https://www.amazon.com/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fwww.amazon.com%2F%3Fref_%3Dnav_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=usflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&"
+        log.info(f"Logging in to {self.amazon_domain}...")
+        tld = self.amazon_domain.split(".")[-1]
+        smile_handle = f"amzn_smile_desktop_{tld}"
+        if tld == "com":
+            smile_handle = "amzn_smile"
+            tld = "us"
+        if tld == "uk":
+            tld = "gb"
+        amazonsmile_url = f"https://{self.amazon_domain}/ap/signin/ref=smi_ge2_ul_si_rl?_encoding=UTF8&ie=UTF8&openid.assoc_handle={smile_handle}&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.ns.pape=http%3A%2F%2Fspecs.openid.net%2Fextensions%2Fpape%2F1.0&openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2F{self.amazon_domain}%2Fgp%2Fcharity%2Fhomepage.html%3Fie%3DUTF8%26%252AVersion%252A%3D1%26%252Aentries%252A%3D0%26newts%3D1%26ref_%3Dsmi_chpf_redirect"
+        amazoncom_url = f"https://{self.amazon_domain}/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2F{self.amazon_domain}%2F%3Fref_%3Dnav_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle={tld}flex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&"
         email_field: Optional[WebElement] = None
         remember_me: Optional[WebElement] = None
         password_field: Optional[WebElement] = None
 
-        if "smile" in domain:
+        if "smile" in self.amazon_domain:
             url = amazonsmile_url
         else:
             url = amazoncom_url
@@ -411,8 +418,7 @@ class AmazonCheckoutHandler(BaseStoreHandler):
             self.checkout_session.headers["x-amz-checkout-csrf-token"] = session_id
         self.checkout_session.cookie_jar.update_cookies(cookies)
         # It appears the amazon session is valid for 366 days.
-        domain = "smile.amazon.com"
-        resp = await self.checkout_session.get(f"https://{domain}")
+        resp = await self.checkout_session.get(f"https://{self.amazon_domain}")
         html_text = await resp.text()
         save_html_response("session-get", resp.status, html_text)
         while True:
@@ -428,12 +434,17 @@ class AmazonCheckoutHandler(BaseStoreHandler):
             anti_csrf = None
             while (not (pid and anti_csrf)) and retry < TURBO_INITIATE_MAX_RETRY:
                 pid, anti_csrf = await turbo_initiate(
-                    s=self.checkout_session, qualified_seller=qualified_seller
+                    domain=self.amazon_domain,
+                    s=self.checkout_session,
+                    qualified_seller=qualified_seller,
                 )
                 retry += 1
             if pid and anti_csrf:
                 if await turbo_checkout(
-                    s=self.checkout_session, pid=pid, anti_csrf=anti_csrf
+                    domain=self.amazon_domain,
+                    s=self.checkout_session,
+                    pid=pid,
+                    anti_csrf=anti_csrf,
                 ):
                     log.info("Maybe completed checkout")
                     time_difference = time.time() - start_time
@@ -443,7 +454,7 @@ class AmazonCheckoutHandler(BaseStoreHandler):
                     try:
                         status, text = await aio_get(
                             self.checkout_session,
-                            f"https://{domain}/gp/buy/thankyou/handlers/display.html?_from=cheetah&checkMFA=1&purchaseId={pid}&referrer=yield&pid={pid}&pipelineType=turbo&clientId=retailwebsite&temporaryAddToCart=1&hostPage=detail&weblab=RCX_CHECKOUT_TURBO_DESKTOP_PRIME_87783",
+                            f"https://{self.amazon_domain}/gp/buy/thankyou/handlers/display.html?_from=cheetah&checkMFA=1&purchaseId={pid}&referrer=yield&pid={pid}&pipelineType=turbo&clientId=retailwebsite&temporaryAddToCart=1&hostPage=detail&weblab=RCX_CHECKOUT_TURBO_DESKTOP_PRIME_87783",
                         )
                         save_html_response("order-confirm", status, text)
                     except aiohttp.ClientError:
@@ -495,9 +506,8 @@ async def aio_get(client, url, data=None):
 
 @timer
 async def turbo_initiate(
-    s: aiohttp.ClientSession, qualified_seller: Optional[SellerDetail] = None
+    domain, s: aiohttp.ClientSession, qualified_seller: Optional[SellerDetail] = None
 ):
-    domain = "smile.amazon.com"
     url = f"https://{domain}/checkout/turbo-initiate?ref_=dp_start-bbf_1_glance_buyNow_2-1&pipelineType=turbo&weblab=RCX_CHECKOUT_TURBO_DESKTOP_NONPRIME_87784&temporaryAddToCart=1"
     pid = None
     anti_csrf = None
@@ -543,8 +553,7 @@ async def turbo_initiate(
 
 
 @timer
-async def turbo_checkout(s: aiohttp.ClientSession, pid, anti_csrf):
-    domain = "smile.amazon.com"
+async def turbo_checkout(domain, s: aiohttp.ClientSession, pid, anti_csrf):
     log.debug("trying to checkout")
     url = f"https://{domain}/checkout/spc/place-order?ref_=chk_spc_placeOrder&clientId=retailwebsite&pipelineType=turbo&pid={pid}"
     header_update = {"anti-csrftoken-a2z": anti_csrf}

--- a/stores/amazon_handler.py
+++ b/stores/amazon_handler.py
@@ -80,19 +80,25 @@ class AmazonStoreHandler(BaseStoreHandler):
         global queue
         queue = asyncio.Queue()
         log.debug("Creating checkout handler")
+        if self.amazon_domain.endswith(".com"):
+            cookie_suffix = "main"
+        else:
+            cookie_suffix = "acb" + self.amazon_domain.split(".")[-1]
+        cookie_list = [
+            "session-id",
+            "x-amz-captcha-1",
+            "x-amz-captcha-2",
+            f"ubid-{cookie_suffix}",
+            f"x-{cookie_suffix}",
+            f"at-{cookie_suffix}",
+            f"sess-at-{cookie_suffix}",
+        ]
         amazon_checkout = AmazonCheckoutHandler(
             notification_handler=self.notification_handler,
             amazon_config=amazon_config,
-            cookie_list=[
-                "session-id",
-                "x-amz-captcha-1",
-                "x-amz-captcha-2",
-                "ubid-main",
-                "x-main",
-                "at-main",
-                "sess-at-main",
-            ],
+            cookie_list=cookie_list,
             profile_path=self.profile_path,
+            amazon_domain=self.amazon_domain,
         )
         log.debug("Creating monitoring handler")
         amazon_monitoring = AmazonMonitoringHandler(
@@ -181,7 +187,7 @@ class AmazonStoreHandler(BaseStoreHandler):
                             condition=condition,
                             merchant_id=merchant_id,
                             furl=furl(
-                                url=f"https://smile.amazon.com/gp/aod/ajax?asin={asin}"
+                                url=f"https://{self.amazon_domain}/gp/aod/ajax?asin={asin}"
                             ),
                         )
                     )


### PR DESCRIPTION
This also picks up the work from https://github.com/Hari-Nagarajan/fairgame/pull/691 where we apply cookies based on the TLD.

Two notes:
- The US flex is `us` and UK is `gb`.
- The smile handle for UK is `uk`