### PR TITLE
Add new amazon.com home page title to fairgame.conf

### DIFF
--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -66,6 +66,7 @@
     ],
     "HOME_PAGE_TITLES": [
       "Amazon.com: Online Shopping for Electronics, Apparel, Computers, Books, DVDs & more",
+      "Amazon.com. Spend less. Smile more.",
       "AmazonSmile: You shop. Amazon gives.",
       "Amazon.ca: Low Prices – Fast Shipping – Millions of Items",
       "Amazon.co.uk: Low Prices in Electronics, Books, Sports Equipment & more",

--- a/config/fairgame.conf
+++ b/config/fairgame.conf
@@ -66,7 +66,6 @@
     ],
     "HOME_PAGE_TITLES": [
       "Amazon.com: Online Shopping for Electronics, Apparel, Computers, Books, DVDs & more",
-      "Amazon.com. Spend less. Smile more.",
       "AmazonSmile: You shop. Amazon gives.",
       "Amazon.ca: Low Prices – Fast Shipping – Millions of Items",
       "Amazon.co.uk: Low Prices in Electronics, Books, Sports Equipment & more",


### PR DESCRIPTION
Added new title page text and left the original in the list. Not sure if the original text is still in use. Fixes a "waiting for homepage" error in the consol. 