### PR TITLE
Fix getting asin from html tree. Update chromedriver to latest available.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ pyinstaller = "*"
 requests = {extras = ["socks"], version = "*"}
 click = "*"
 selenium = "*"
-chromedriver-py = "~=91.0.4472.19"
+chromedriver-py = "~=92.0.4515.43"
 furl = "*"
 twilio = "*"
 discord-webhook = "*"

--- a/stores/amazon_monitoring.py
+++ b/stores/amazon_monitoring.py
@@ -372,12 +372,13 @@ def get_item_sellers(
     """Parse out information to from the aod-offer nodes populate ItemDetail instances for each item"""
     sellers: Optional[List[SellerDetail]] = []
     if tree is None:
-        return sellers
+        return sellers 
 
-    # Default response
+    # Default response 
     found_asin = "[NO ASIN FOUND ON PAGE]"
     # First see if ASIN can be found with xpath
     # look for product ASIN
+    #print(html.tostring(tree))
     page_asin = tree.xpath("//input[@id='ftSelectAsin' or @id='ddmSelectAsin']")
     if page_asin:
         try:
@@ -387,7 +388,7 @@ def get_item_sellers(
     # if cannot find with xpath, try regex
     else:
         find_asin = re.search(
-            r"asin\s?(?:=|\.)?\s?\"?([A-Z0-9]+)\"?", tree.text_content()
+            r"asin\s?\"?\:?\s?\"?([A-Z0-9]+)\"?", str(html.tostring(tree))
         )
         if find_asin:
             found_asin = find_asin.group(1)


### PR DESCRIPTION
Before, no asin existed in `tree.text_content()`, so the regex search will be performed on` html.tostring(tree)` now which includes the entire html page. Modified the regex query for this purpose.
A bit dirty but this will avoid future errors when amazon decides to update again as long as they maintain the pattern `"asin":"asinvalue"`.
Also updated the chromedriver version to the latest one available.