### PR TITLE
Update Pipfile to use latest ChromeDriver

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ pyinstaller = "*"
 requests = {extras = ["socks"], version = "*"}
 click = "*"
 selenium = "*"
-chromedriver-py = "~=92.0.4515.43"
+chromedriver-py = "~=95.0.4638.17"
 furl = "*"
 twilio = "*"
 discord-webhook = "*"


### PR DESCRIPTION
Updating Pipfile to use latest ChromeDriver, 95.0.4638.17
https://pypi.org/project/chromedriver-py/#history

Presently using v92 which is old.